### PR TITLE
Fix command injection vulnerability

### DIFF
--- a/dcnnt/plugins/notifications.py
+++ b/dcnnt/plugins/notifications.py
@@ -1,5 +1,6 @@
 import logging
 import subprocess
+from shlex import quote
 
 from .base import Plugin
 from ..common import *
@@ -53,6 +54,6 @@ class NotificationsPlugin(Plugin):
                         except Exception as e:
                             self.log(e, logging.WARNING)
                     icon = icon_path if icon_data else ''
-                    command = cmd.format(uin=uin, name=name, icon=icon, text=text, title=title, package=package)
+                    command = cmd.format(uin=quote(uin), name=quote(name), icon=quote(icon), text=quote(text), title=quote(title), package=quote(package))
                     self.log('Execute: "{}"'.format(command))
                     subprocess.call(command, shell=True)


### PR DESCRIPTION
Fix passing of unescaped text to the arguments of notification command in dcnnt/plugins/notifications.py

This is a high-risk vulnerability that can lead to RCE and allow arbitrary code execution on the server while the notification showing.

All text received over the network MUST be escaped before being transmitted to the database or to the shell command arguments.

(Old PR was closed due to accidental deletion of the repository)